### PR TITLE
show/hide epg setting

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,6 +5,7 @@
   <category label="30100">
   	<setting id="login" type="text" label="30110" />
     <setting id="password" type="text" label="30111" option="hidden"/>
+    <setting id="epg" label="EPG" type="bool" default="true" />
   </category>
 
 </settings>

--- a/teleboy.py
+++ b/teleboy.py
@@ -1,7 +1,7 @@
 
 import os, re, sys, base64
 import cookielib, urllib, urllib2
-import xbmcgui, xbmcplugin, xbmcaddon
+import xbmc, xbmcgui, xbmcplugin, xbmcaddon
 from mindmade import *
 import simplejson
 
@@ -137,6 +137,7 @@ def addDirectoryItem( name, params={}, image="", total=0, isFolder=False):
     for k in params.keys():
         params_encoded[k] = params[k].encode( "utf-8")
     url = sys.argv[0] + '?' + urllib.urlencode( params_encoded)
+    #xbmc.log("%s=%s" % (name,url))
     return xbmcplugin.addDirectoryItem(handle=pluginhandle, url=url, listitem=li, isFolder = isFolder, totalItems=total)
 ###########
 # END TEMP
@@ -161,13 +162,16 @@ def show_main():
 
     content = fetchApiJson( user_id, "broadcasts/now", { "expand": "flags,station,previewImage", "stream": True })
     print( repr(content))
-    for item in content["data"]["items"]:
+    for item in sorted(content["data"]["items"], key=lambda x: x["station"]["name"]):
         channel = item["station"]["name"]
         station_id = str(item["station"]["id"])
         title   = item["title"]
         tstart  = item["begin"][11:16]
         tend    = item["end"][11:16]
-        label   = channel + ": " + title + " (" + tstart + "-" + tend +")"
+        if settings.getSetting('epg') == 'true':
+            label   = channel + ": " + title + " (" + tstart + "-" + tend +")"
+        else:
+            label   = channel
         img     = get_stationLogoURL( station_id)
         addDirectoryItem( label, { PARAMETER_KEY_STATION: station_id,
                           PARAMETER_KEY_MODE: MODE_PLAY,


### PR DESCRIPTION
Hi. Could you add in a toggle to hide the epg data so the channels can be easily added to TV Guides.

There is a sort for the channels too which would make it easier to find the channels.
I know they can be sorted in the Teleboy website too so this is just an idea.