### PR TITLE
pass referer in header when login in

### DIFF
--- a/teleboy.py
+++ b/teleboy.py
@@ -56,8 +56,9 @@ def ensure_login():
     args = { "login": login,
              "password": password,
              "keep_login": "1" }
+    hdrs = { "Referer": TB_URL }
 
-    reply = fetchHttp( url, args, post=True);
+    reply = fetchHttp( url, args, hdrs, post=True);
 
     if "Falsche Eingaben" in reply or "Anmeldung war nicht erfolgreich" in reply:
         log( "login failure")


### PR DESCRIPTION
An error 500 (internal server error) is returned without referer.